### PR TITLE
Add PlatformIO Library Registry manifest file

### DIFF
--- a/Arduino/library.json
+++ b/Arduino/library.json
@@ -1,0 +1,13 @@
+{
+  "name": "AVRQueue",
+  "keywords": "task, queue",
+  "description": "A task queuing library for AVR and Arduino processors.",
+  "repository":
+  {
+    "type": "git",
+    "url": "https://github.com/Zuph/AVRQueue"
+  },
+  "include": "Arduino",
+  "frameworks": "arduino",
+  "platforms": "atmelavr"
+}


### PR DESCRIPTION
Add library.json file. This allows the library to be used from within PlatformIO (see http://platformio.org/)
